### PR TITLE
feat: add permission to agent

### DIFF
--- a/src/agents/abis/authentications.json
+++ b/src/agents/abis/authentications.json
@@ -1,4 +1,4 @@
 [
-  "function add_alias(string alias)",
-  "function remove_alias(string alias)"
+  "function addAlias(string alias, string target)",
+  "function authenticate(string alias, string target)"
 ]

--- a/src/agents/abis/authentications.json
+++ b/src/agents/abis/authentications.json
@@ -1,0 +1,4 @@
+[
+  "function add_alias(string alias)",
+  "function remove_alias(string alias)"
+]

--- a/src/agents/authentications.ts
+++ b/src/agents/authentications.ts
@@ -1,28 +1,20 @@
 import Agent from '../highlight/agent';
 
 export default class Authentications extends Agent {
-  async add_alias(alias: string) {
-    console.log('add_alias', alias);
+  async add_alias(alias: string, target: string) {
+    console.log('add_alias', alias, target);
 
-    const sender = this.process.sender;
+    this.assert(await this.has(`alias.${alias}`), 'invalid alias');
+    this.assert(target !== this.process.sender, 'unauthorized');
 
-    this.write(`alias.${alias}`, true);
-    this.write(`owner.alias.${alias}`, sender);
+    this.write(`alias.${alias}`, target);
 
-    this.emit('add_alias', [alias, sender]);
+    this.emit('add_alias', [alias, target]);
   }
 
-  async remove_alias(alias: string) {
-    console.log('remove_alias', alias);
+  async authenticate(alias: string, target: string): Promise<boolean> {
+    console.log('is_authorized', alias, target);
 
-    const sender = this.process.sender;
-
-    this.assert(!(await this.has(`alias.${alias}`)), 'invalid alias');
-    this.assert((await this.get(`owner.alias.${alias}`)) !== sender, 'no permission');
-
-    this.delete(`alias.${alias}`);
-    this.delete(`owner.alias.${alias}`);
-
-    this.emit('remove_alias', [alias, sender]);
+    return alias === target || target === (await this.get(`alias.${alias}`));
   }
 }

--- a/src/agents/authentications.ts
+++ b/src/agents/authentications.ts
@@ -1,0 +1,28 @@
+import Agent from '../highlight/agent';
+
+export default class Authentications extends Agent {
+  async add_alias(alias: string) {
+    console.log('add_alias', alias);
+
+    const sender = this.process.sender;
+
+    this.write(`alias.${alias}`, true);
+    this.write(`owner.alias.${alias}`, sender);
+
+    this.emit('add_alias', [alias, sender]);
+  }
+
+  async remove_alias(alias: string) {
+    console.log('remove_alias', alias);
+
+    const sender = this.process.sender;
+
+    this.assert(!(await this.has(`alias.${alias}`)), 'invalid alias');
+    this.assert((await this.get(`owner.alias.${alias}`)) !== sender, 'no permission');
+
+    this.delete(`alias.${alias}`);
+    this.delete(`owner.alias.${alias}`);
+
+    this.emit('remove_alias', [alias, sender]);
+  }
+}

--- a/src/agents/discussions.ts
+++ b/src/agents/discussions.ts
@@ -9,9 +9,8 @@ export default class Discussions extends Agent {
 
     this.assert(parent !== 0 && !(await this.has(`category.${parent}`)), 'invalid category');
 
-    this.write(`category.${id}`, true);
+    this.write(`category.${id}`, this.process.sender);
     this.write('next_category_id', id + 1);
-    this.write(`owner.category.${id}`, this.process.sender);
 
     this.emit('add_category', [id, parent, metadataURI]);
   }
@@ -19,7 +18,7 @@ export default class Discussions extends Agent {
   async edit_category(category: number, metadataURI: string) {
     console.log('edit_category', category, metadataURI);
 
-    await this.authenticate(this.process.sender, await this.get(`owner.category.${category}`));
+    await this.authenticate(this.process.sender, await this.get(`category.${category}`));
 
     this.emit('edit_category', [category, metadataURI]);
   }
@@ -28,10 +27,9 @@ export default class Discussions extends Agent {
     console.log('remove_category', category);
 
     this.assert(!(await this.has(`category.${category}`)), 'invalid category');
-    await this.authenticate(this.process.sender, await this.get(`owner.category.${category}`));
+    await this.authenticate(this.process.sender, await this.get(`category.${category}`));
 
     this.delete(`category.${category}`);
-    this.delete(`owner.category.${category}`);
 
     this.emit('remove_category', [category]);
   }
@@ -44,9 +42,8 @@ export default class Discussions extends Agent {
 
     const id = (await this.get('next_topic_id')) || 1;
 
-    this.write(`topic.${id}`, true);
+    this.write(`topic.${id}`, this.process.sender);
     this.write('next_topic_id', id + 1);
-    this.write(`owner.topic.${id}`, this.process.sender);
 
     this.emit('add_topic', [id, author, category, parent, metadataURI]);
   }
@@ -55,7 +52,7 @@ export default class Discussions extends Agent {
     console.log('edit_topic', topic, metadataURI);
 
     this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
-    await this.authenticate(this.process.sender, await this.get(`owner.topic.${topic}`));
+    await this.authenticate(this.process.sender, await this.get(`topic.${topic}`));
 
     this.emit('edit_topic', [topic, metadataURI]);
   }
@@ -64,10 +61,9 @@ export default class Discussions extends Agent {
     console.log('remove_topic', topic);
 
     this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
-    await this.authenticate(this.process.sender, await this.get(`owner.topic.${topic}`));
+    await this.authenticate(this.process.sender, await this.get(`topic.${topic}`));
 
     this.delete(`topic.${topic}`);
-    this.delete(`owner.topic.${topic}`);
 
     this.emit('remove_topic', [topic]);
   }
@@ -76,7 +72,7 @@ export default class Discussions extends Agent {
     console.log('pin_topic', topic);
 
     this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
-    await this.authenticate(this.process.sender, await this.get(`owner.topic.${topic}`));
+    await this.authenticate(this.process.sender, await this.get(`topic.${topic}`));
 
     this.emit('pin_topic', [topic]);
   }
@@ -85,7 +81,7 @@ export default class Discussions extends Agent {
     console.log('unpin_topic', topic);
 
     this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
-    await this.authenticate(this.process.sender, await this.get(`owner.topic.${topic}`));
+    await this.authenticate(this.process.sender, await this.get(`topic.${topic}`));
 
     this.emit('unpin_topic', [topic]);
   }
@@ -96,7 +92,7 @@ export default class Discussions extends Agent {
     this.assert(!voter, 'invalid voter');
     this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
 
-    this.write(`owner.vote.${voter}`, this.process.sender);
+    this.write(`vote.${voter}`, this.process.sender);
 
     this.emit('vote', [voter, topic, choice]);
   }
@@ -106,7 +102,7 @@ export default class Discussions extends Agent {
 
     this.assert(!voter, 'invalid voter');
     this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
-    this.assert((await this.get(`owner.vote.${voter}`)) !== this.process.sender, 'no permission');
+    this.assert((await this.get(`vote.${voter}`)) !== this.process.sender, 'no permission');
 
     this.emit('unvote', [voter, topic]);
   }

--- a/src/agents/discussions.ts
+++ b/src/agents/discussions.ts
@@ -36,6 +36,7 @@ export default class Discussions extends Agent {
     );
 
     this.delete(`category.${category}`);
+    this.delete(`owner.category.${category}`);
 
     this.emit('remove_category', [category]);
   }
@@ -71,6 +72,7 @@ export default class Discussions extends Agent {
     this.assert((await this.get(`owner.topic.${topic}`)) !== this.process.sender, 'no permission');
 
     this.delete(`topic.${topic}`);
+    this.delete(`owner.topic.${topic}`);
 
     this.emit('remove_topic', [topic]);
   }

--- a/src/agents/discussions.ts
+++ b/src/agents/discussions.ts
@@ -12,10 +12,14 @@ export default class Discussions extends Agent {
     this.write('next_category_id', id + 1);
 
     this.emit('add_category', [id, parent, metadataURI]);
+
+    this.createEntity('category', id);
   }
 
   async edit_category(category: number, metadataURI: string) {
     console.log('edit_category', category, metadataURI);
+
+    this.assert(!(await this.hasPermissionOnEntity('category', category)), 'no permission');
 
     this.emit('edit_category', [category, metadataURI]);
   }
@@ -24,6 +28,7 @@ export default class Discussions extends Agent {
     console.log('remove_category', category);
 
     this.assert(!(await this.has(`category.${category}`)), 'invalid category');
+    this.assert(!(await this.hasPermissionOnEntity('category', category)), 'no permission');
 
     this.delete(`category.${category}`);
 
@@ -42,12 +47,15 @@ export default class Discussions extends Agent {
     this.write('next_topic_id', id + 1);
 
     this.emit('add_topic', [id, author, category, parent, metadataURI]);
+
+    this.createEntity('topic', id);
   }
 
   async edit_topic(topic: number, metadataURI: string) {
     console.log('edit_topic', topic, metadataURI);
 
     this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
+    this.assert(!(await this.hasPermissionOnEntity('topic', topic)), 'no permission');
 
     this.emit('edit_topic', [topic, metadataURI]);
   }
@@ -56,6 +64,7 @@ export default class Discussions extends Agent {
     console.log('remove_topic', topic);
 
     this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
+    this.assert(!(await this.hasPermissionOnEntity('topic', topic)), 'no permission');
 
     this.delete(`topic.${topic}`);
 
@@ -65,7 +74,8 @@ export default class Discussions extends Agent {
   async pin_topic(topic: number) {
     console.log('pin_topic', topic);
 
-    await this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
+    this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
+    this.assert(!(await this.hasPermissionOnEntity('topic', topic)), 'no permission');
 
     this.emit('pin_topic', [topic]);
   }
@@ -74,6 +84,7 @@ export default class Discussions extends Agent {
     console.log('unpin_topic', topic);
 
     this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
+    this.assert(!(await this.hasPermissionOnEntity('topic', topic)), 'no permission');
 
     this.emit('unpin_topic', [topic]);
   }
@@ -85,6 +96,8 @@ export default class Discussions extends Agent {
     this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
 
     this.emit('vote', [voter, topic, choice]);
+
+    this.createEntity('vote', voter);
   }
 
   async unvote(voter: string, topic: number) {
@@ -92,6 +105,7 @@ export default class Discussions extends Agent {
 
     this.assert(!voter, 'invalid voter');
     this.assert(!(await this.has(`topic.${topic}`)), 'invalid topic');
+    this.assert(!(await this.hasPermissionOnEntity('vote', voter)), 'no permission');
 
     this.emit('unvote', [voter, topic]);
   }

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,10 +1,12 @@
 import Profiles from './profiles';
 import Discussions from './discussions';
 import Votes from './votes';
+import Authentications from './authentications';
 import Process from '../highlight/process';
 import ProfilesAbi from './abis/profiles.json';
 import DiscussionsAbi from './abis/discussions.json';
 import VotesAbi from './abis/votes.json';
+import AuthenticationsAbi from './abis/authentications.json';
 
 export const AGENTS_MAP = {
   '0x0000000000000000000000000000000000000001': (process: Process) => {
@@ -15,5 +17,8 @@ export const AGENTS_MAP = {
   },
   '0x0000000000000000000000000000000000000003': (process: Process) => {
     return new Votes('votes', process, VotesAbi);
+  },
+  '0x0000000000000000000000000000000000000004': (process: Process) => {
+    return new Authentications('authentications', process, AuthenticationsAbi);
   }
 };

--- a/src/highlight/agent.ts
+++ b/src/highlight/agent.ts
@@ -40,6 +40,14 @@ export default class Agent {
     return await this.process.get(this.id, key);
   }
 
+  createEntity(type: string, id: string | number) {
+    return this.process.createEntity(this.id, type, id);
+  }
+
+  hasPermissionOnEntity(type: string, id: string | number) {
+    return this.process.hasPermissionOnEntity(this.id, type, id);
+  }
+
   write(key: string, value: any) {
     this.process.write({
       agent: this.id,

--- a/src/highlight/agent.ts
+++ b/src/highlight/agent.ts
@@ -40,16 +40,6 @@ export default class Agent {
     return await this.process.get(this.id, key);
   }
 
-  createEntity(type: string, id: string | number) {
-    this.write(`owner.${type}.${id}`, this.process.from);
-    this.emit(type, [id.toString(), this.process.from]);
-  }
-
-  async hasPermissionOnEntity(type: string, id: string | number) {
-    const owner = await this.get(`owner.${type}.${id}`);
-    return owner === this.process.from;
-  }
-
   write(key: string, value: any) {
     this.process.write({
       agent: this.id,

--- a/src/highlight/agent.ts
+++ b/src/highlight/agent.ts
@@ -41,11 +41,13 @@ export default class Agent {
   }
 
   createEntity(type: string, id: string | number) {
-    return this.process.createEntity(this.id, type, id);
+    this.write(`owner.${type}.${id}`, this.process.from);
+    this.emit(type, [id.toString(), this.process.from]);
   }
 
-  hasPermissionOnEntity(type: string, id: string | number) {
-    return this.process.hasPermissionOnEntity(this.id, type, id);
+  async hasPermissionOnEntity(type: string, id: string | number) {
+    const owner = await this.get(`owner.${type}.${id}`);
+    return owner === this.process.from;
   }
 
   write(key: string, value: any) {

--- a/src/highlight/highlight.ts
+++ b/src/highlight/highlight.ts
@@ -29,7 +29,7 @@ export default class Highlight {
     let steps = 0;
 
     if (params.unit.txData.to) {
-      const process = new Process({ adapter: this.adapter });
+      const process = new Process({ adapter: this.adapter, from: params.unit.sender_address });
       try {
         await this.invoke(process, params.unit.txData.to, params.unit.txData.data);
 

--- a/src/highlight/highlight.ts
+++ b/src/highlight/highlight.ts
@@ -29,7 +29,7 @@ export default class Highlight {
     let steps = 0;
 
     if (params.unit.txData.to) {
-      const process = new Process({ adapter: this.adapter, from: params.unit.sender_address });
+      const process = new Process({ adapter: this.adapter, sender: params.unit.sender_address });
       try {
         await this.invoke(process, params.unit.txData.to, params.unit.txData.data);
 

--- a/src/highlight/process.ts
+++ b/src/highlight/process.ts
@@ -7,13 +7,29 @@ export default class Process {
   public writes: Storage[] = [];
   public state: Record<string, Record<string, string>> = {};
   public steps = 0;
+  public from: string;
 
-  constructor({ adapter }) {
+  constructor({ adapter, from }) {
     this.adapter = adapter;
+    this.from = from;
   }
 
   emit(event: Event) {
     this.events.push(event);
+  }
+
+  createEntity(agent: string, type: string, id: string | number) {
+    this.write({ agent, key: `owner.${type}.${id}`, value: this.from });
+    this.emit({
+      agent,
+      key: type,
+      data: [id.toString(), this.from]
+    });
+  }
+
+  async hasPermissionOnEntity(agent: string, type: string, id: string | number) {
+    const owner = await this.get(agent, `owner.${type}.${id}`);
+    return owner === this.from;
   }
 
   async get(agent: string, key: string) {

--- a/src/highlight/process.ts
+++ b/src/highlight/process.ts
@@ -7,11 +7,11 @@ export default class Process {
   public writes: Storage[] = [];
   public state: Record<string, Record<string, string>> = {};
   public steps = 0;
-  public from: string;
+  public sender: string;
 
-  constructor({ adapter, from }) {
+  constructor({ adapter, sender }) {
     this.adapter = adapter;
-    this.from = from;
+    this.sender = sender;
   }
 
   emit(event: Event) {

--- a/src/highlight/process.ts
+++ b/src/highlight/process.ts
@@ -18,20 +18,6 @@ export default class Process {
     this.events.push(event);
   }
 
-  createEntity(agent: string, type: string, id: string | number) {
-    this.write({ agent, key: `owner.${type}.${id}`, value: this.from });
-    this.emit({
-      agent,
-      key: type,
-      data: [id.toString(), this.from]
-    });
-  }
-
-  async hasPermissionOnEntity(agent: string, type: string, id: string | number) {
-    const owner = await this.get(agent, `owner.${type}.${id}`);
-    return owner === this.from;
-  }
-
   async get(agent: string, key: string) {
     const storage = this.state[`${agent}:${key}`];
     if (storage) return storage;


### PR DESCRIPTION
- Associate a wallet address to an entity (category, topic, topic-vote)
- Use authentications agent to check if the entity can be edited/removed by the sender or its alias