### PR TITLE
fix: map API choices to UI used values

### DIFF
--- a/src/api/writer.ts
+++ b/src/api/writer.ts
@@ -335,10 +335,14 @@ export const handleSetStatement = async ({ payload }) => {
 export const handleVote = async ({ payload }) => {
   console.log('Handle vote', payload);
 
-  const [space, voter, proposalId, choice, chainId, sig] = payload.data;
+  const [space, voter, proposalId, rawChoice, chainId, sig] = payload.data;
   const uniqueProposalId = `${space}/${proposalId}`;
   const id = `${uniqueProposalId}/${voter}`;
   const timestamp = ~~(Date.now() / 1e3); // @TODO change to unit timestamp
+  let choice = rawChoice;
+  if (rawChoice === 0) choice = 2;
+  else if (rawChoice === 1) choice = 1;
+  else if (rawChoice === 2) choice = 3;
 
   const vp = await getVotingPower(space, proposalId, voter, chainId);
   const userEntity: SXUser = await getEntity(SXUser, voter);


### PR DESCRIPTION
Remapping EVM specific values to UI ones (same as on Subgraph): Against: 0 -> 2
For: 1 -> 1
Abstain: 2 -> 3

https://github.com/snapshot-labs/sx-evm/blob/a17a4abbc8a35276163fbbb051bf14c879980b96/src/types.sol#L75-L80 https://github.com/snapshot-labs/sx-monorepo/blob/3110ad14f88fd82d9c375b51ecf42b32f3a6c535/apps/subgraph-api/src/mapping.ts#L397-L401

From [this](https://github.com/snapshot-labs/sx-monorepo/pull/401) it looks like vote from there is not abstain, but against. Are you sure it was abstain?

