### PR TITLE
feat: integrate alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@ethersproject/wallet": "^5.8.0",
     "@snapshot-labs/checkpoint": "^0.1.0-beta.57",
     "async-lock": "^1.4.0",
-    "change-case": "^4.1.0",
     "connection-string": "^1.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",

--- a/src/agents/abis/aliases.json
+++ b/src/agents/abis/aliases.json
@@ -1,3 +1,3 @@
 [
-  "function setAlias(address from, address alias, uint64 timestamp, uint256 salt, bytes signature)"
+  "function setAlias(address from, address alias, uint256 salt, bytes signature)"
 ]

--- a/src/agents/abis/aliases.json
+++ b/src/agents/abis/aliases.json
@@ -1,3 +1,3 @@
 [
-  "function setAlias(address from, address alias, salt uint256, signature bytes)"
+  "function setAlias(address from, address alias, timestamp uint64, salt uint256, signature bytes)"
 ]

--- a/src/agents/abis/aliases.json
+++ b/src/agents/abis/aliases.json
@@ -1,3 +1,3 @@
 [
-  "function setAlias(address from, address alias, timestamp uint64, salt uint256, signature bytes)"
+  "function setAlias(address from, address alias, uint64 timestamp, uint256 salt, bytes signature)"
 ]

--- a/src/agents/aliases.test.ts
+++ b/src/agents/aliases.test.ts
@@ -89,7 +89,7 @@ it('should throw if salt is reused', async () => {
 
   const message = {
     from,
-    alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+    alias: '0xEDeF22EA0505C7296D24109bD90001668493777D',
     timestamp: 1744209444n,
     salt: getSalt()
   };
@@ -105,6 +105,37 @@ it('should throw if salt is reused', async () => {
   await expect(
     aliases.setAlias(from, message.alias, message.salt, signature)
   ).rejects.toThrow('Salt already used');
+
+  expect(process.events).toHaveLength(1);
+});
+
+it('should throw if alias is reused', async () => {
+  const process = new Process({ adapter });
+  const aliases = new Aliases('aliases', process, AliasesAbi);
+
+  const from = await wallet.getAddress();
+
+  const message = {
+    from,
+    alias: '0x9905a3A1bAE3b10AD163Bb3735aE87cd70b84eC4',
+    timestamp: 1744209444n,
+    salt: getSalt()
+  };
+
+  let signature = await signMessage(wallet, SET_ALIAS_TYPES, message);
+
+  await expect(
+    aliases.setAlias(from, message.alias, message.salt, signature)
+  ).resolves.toBeUndefined();
+
+  expect(process.events).toHaveLength(1);
+
+  message.salt = getSalt();
+  signature = await signMessage(wallet, SET_ALIAS_TYPES, message);
+
+  await expect(
+    aliases.setAlias(from, message.alias, message.salt, signature)
+  ).rejects.toThrow('Alias already exists');
 
   expect(process.events).toHaveLength(1);
 });

--- a/src/agents/aliases.test.ts
+++ b/src/agents/aliases.test.ts
@@ -68,3 +68,30 @@ it('should throw if signature is invalid', async () => {
 
   expect(process.events).toHaveLength(0);
 });
+
+it('should throw if salt is reused', async () => {
+  const process = new Process({ adapter });
+  const aliases = new Aliases('aliases', process, AliasesAbi);
+
+  const from = await wallet.getAddress();
+
+  const message = {
+    from,
+    alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+    salt: getSalt()
+  };
+
+  const signature = await signMessage(wallet, SET_ALIAS_TYPES, message);
+
+  await expect(
+    aliases.setAlias(from, message.alias, message.salt, signature)
+  ).resolves.toBeUndefined();
+
+  expect(process.events).toHaveLength(1);
+
+  await expect(
+    aliases.setAlias(from, message.alias, message.salt, signature)
+  ).rejects.toThrow('Salt already used');
+
+  expect(process.events).toHaveLength(1);
+});

--- a/src/agents/aliases.test.ts
+++ b/src/agents/aliases.test.ts
@@ -37,20 +37,13 @@ it('should allow alias if signature is valid', async () => {
   const message = {
     from,
     alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
-    timestamp: 1744209444n,
     salt: getSalt()
   };
 
   const signature = await signMessage(wallet, SET_ALIAS_TYPES, message);
 
   await expect(
-    aliases.setAlias(
-      from,
-      message.alias,
-      message.timestamp,
-      message.salt,
-      signature
-    )
+    aliases.setAlias(from, message.alias, message.salt, signature)
   ).resolves.toBeUndefined();
 
   expect(process.events).toEqual([
@@ -59,7 +52,6 @@ it('should allow alias if signature is valid', async () => {
       data: [
         from,
         '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
-        '0x67f68624',
         `0x${message.salt.toString(16)}`
       ],
       key: 'setAlias'
@@ -76,7 +68,6 @@ it('should throw if signature is invalid', async () => {
   const message = {
     from,
     alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
-    timestamp: 1744209444n,
     salt: getSalt()
   };
 
@@ -84,13 +75,7 @@ it('should throw if signature is invalid', async () => {
     '0x8b44096237326cc5e9c67f6c847a46f8715945d216269d63e6bc09712d91ba7b48e8ceef2d1c62b37debeda708e6bd1f0a5d5822cd88273830599e51d9d8b78c1b';
 
   await expect(
-    aliases.setAlias(
-      from,
-      message.alias,
-      message.timestamp,
-      message.salt,
-      signature
-    )
+    aliases.setAlias(from, message.alias, message.salt, signature)
   ).rejects.toThrow('Invalid signature');
 
   expect(process.events).toHaveLength(0);
@@ -112,25 +97,13 @@ it('should throw if salt is reused', async () => {
   const signature = await signMessage(wallet, SET_ALIAS_TYPES, message);
 
   await expect(
-    aliases.setAlias(
-      from,
-      message.alias,
-      message.timestamp,
-      message.salt,
-      signature
-    )
+    aliases.setAlias(from, message.alias, message.salt, signature)
   ).resolves.toBeUndefined();
 
   expect(process.events).toHaveLength(1);
 
   await expect(
-    aliases.setAlias(
-      from,
-      message.alias,
-      message.timestamp,
-      message.salt,
-      signature
-    )
+    aliases.setAlias(from, message.alias, message.salt, signature)
   ).rejects.toThrow('Salt already used');
 
   expect(process.events).toHaveLength(1);

--- a/src/agents/aliases.test.ts
+++ b/src/agents/aliases.test.ts
@@ -35,22 +35,26 @@ it('should allow alias if signature is valid', async () => {
   const message = {
     from,
     alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+    timestamp: 1744209444,
     salt: getSalt()
   };
 
   const signature = await signMessage(wallet, SET_ALIAS_TYPES, message);
 
   await expect(
-    aliases.setAlias(from, message.alias, message.salt, signature)
+    aliases.setAlias(
+      from,
+      message.alias,
+      message.timestamp,
+      message.salt,
+      signature
+    )
   ).resolves.toBeUndefined();
 
-  expect(process.events).toMatchInlineSnapshot([
+  expect(process.events).toEqual([
     {
       agent: 'aliases',
-      data: [
-        '0x8E2E3A9077712A1Ce072F95f1DDe62210dd0A0EC',
-        '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'
-      ],
+      data: [from, '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'],
       key: 'setAlias'
     }
   ]);
@@ -65,6 +69,7 @@ it('should throw if signature is invalid', async () => {
   const message = {
     from,
     alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+    timestamp: 1744209444,
     salt: getSalt()
   };
 
@@ -72,7 +77,13 @@ it('should throw if signature is invalid', async () => {
     '0x8b44096237326cc5e9c67f6c847a46f8715945d216269d63e6bc09712d91ba7b48e8ceef2d1c62b37debeda708e6bd1f0a5d5822cd88273830599e51d9d8b78c1b';
 
   await expect(
-    aliases.setAlias(from, message.alias, message.salt, signature)
+    aliases.setAlias(
+      from,
+      message.alias,
+      message.timestamp,
+      message.salt,
+      signature
+    )
   ).rejects.toThrow('Invalid signature');
 
   expect(process.events).toHaveLength(0);
@@ -87,19 +98,32 @@ it('should throw if salt is reused', async () => {
   const message = {
     from,
     alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+    timestamp: 1744209444,
     salt: getSalt()
   };
 
   const signature = await signMessage(wallet, SET_ALIAS_TYPES, message);
 
   await expect(
-    aliases.setAlias(from, message.alias, message.salt, signature)
+    aliases.setAlias(
+      from,
+      message.alias,
+      message.timestamp,
+      message.salt,
+      signature
+    )
   ).resolves.toBeUndefined();
 
   expect(process.events).toHaveLength(1);
 
   await expect(
-    aliases.setAlias(from, message.alias, message.salt, signature)
+    aliases.setAlias(
+      from,
+      message.alias,
+      message.timestamp,
+      message.salt,
+      signature
+    )
   ).rejects.toThrow('Salt already used');
 
   expect(process.events).toHaveLength(1);

--- a/src/agents/aliases.test.ts
+++ b/src/agents/aliases.test.ts
@@ -23,7 +23,9 @@ function getSalt() {
   const buffer = new Uint8Array(32);
   crypto.getRandomValues(buffer);
 
-  return `0x${buffer.reduce((acc, val) => acc + val.toString(16).padStart(2, '0'), '')}`;
+  return BigInt(
+    `0x${buffer.reduce((acc, val) => acc + val.toString(16).padStart(2, '0'), '')}`
+  );
 }
 
 it('should allow alias if signature is valid', async () => {
@@ -35,7 +37,7 @@ it('should allow alias if signature is valid', async () => {
   const message = {
     from,
     alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
-    timestamp: 1744209444,
+    timestamp: 1744209444n,
     salt: getSalt()
   };
 
@@ -54,7 +56,12 @@ it('should allow alias if signature is valid', async () => {
   expect(process.events).toEqual([
     {
       agent: 'aliases',
-      data: [from, '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'],
+      data: [
+        from,
+        '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+        '0x67f68624',
+        `0x${message.salt.toString(16)}`
+      ],
       key: 'setAlias'
     }
   ]);
@@ -69,7 +76,7 @@ it('should throw if signature is invalid', async () => {
   const message = {
     from,
     alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
-    timestamp: 1744209444,
+    timestamp: 1744209444n,
     salt: getSalt()
   };
 
@@ -98,7 +105,7 @@ it('should throw if salt is reused', async () => {
   const message = {
     from,
     alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
-    timestamp: 1744209444,
+    timestamp: 1744209444n,
     salt: getSalt()
   };
 

--- a/src/agents/aliases.test.ts
+++ b/src/agents/aliases.test.ts
@@ -44,7 +44,16 @@ it('should allow alias if signature is valid', async () => {
     aliases.setAlias(from, message.alias, message.salt, signature)
   ).resolves.toBeUndefined();
 
-  expect(process.events).toHaveLength(1);
+  expect(process.events).toMatchInlineSnapshot([
+    {
+      agent: 'aliases',
+      data: [
+        '0x8E2E3A9077712A1Ce072F95f1DDe62210dd0A0EC',
+        '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'
+      ],
+      key: 'setAlias'
+    }
+  ]);
 });
 
 it('should throw if signature is invalid', async () => {

--- a/src/agents/aliases.ts
+++ b/src/agents/aliases.ts
@@ -5,16 +5,24 @@ export const SET_ALIAS_TYPES = {
   Alias: [
     { name: 'from', type: 'address' },
     { name: 'alias', type: 'address' },
+    { name: 'timestamp', type: 'uint64' },
     { name: 'salt', type: 'uint256' }
   ]
 };
 export default class Aliases extends Agent {
-  async setAlias(from: string, alias: string, salt: string, signature: string) {
+  async setAlias(
+    from: string,
+    alias: string,
+    timestamp: number,
+    salt: string,
+    signature: string
+  ) {
     const recoveredAddress = await verifySignature(
       SET_ALIAS_TYPES,
       {
         from,
         alias,
+        timestamp,
         salt
       },
       signature

--- a/src/agents/aliases.ts
+++ b/src/agents/aliases.ts
@@ -25,6 +25,6 @@ export default class Aliases extends Agent {
     this.assert(saltAlreadyUsed === false, 'Salt already used');
 
     this.write(`salts:${salt}`, true);
-    this.emit('setAlias', []);
+    this.emit('setAlias', [from, alias]);
   }
 }

--- a/src/agents/aliases.ts
+++ b/src/agents/aliases.ts
@@ -19,9 +19,12 @@ export default class Aliases extends Agent {
       },
       signature
     );
-
     this.assert(recoveredAddress === from, 'Invalid signature');
 
+    const saltAlreadyUsed = await this.has(`salts:${salt}`);
+    this.assert(saltAlreadyUsed === false, 'Salt already used');
+
+    this.write(`salts:${salt}`, true);
     this.emit('setAlias', []);
   }
 }

--- a/src/agents/aliases.ts
+++ b/src/agents/aliases.ts
@@ -5,24 +5,16 @@ export const SET_ALIAS_TYPES = {
   Alias: [
     { name: 'from', type: 'address' },
     { name: 'alias', type: 'address' },
-    { name: 'timestamp', type: 'uint64' },
     { name: 'salt', type: 'uint256' }
   ]
 };
 export default class Aliases extends Agent {
-  async setAlias(
-    from: string,
-    alias: string,
-    timestamp: bigint,
-    salt: bigint,
-    signature: string
-  ) {
+  async setAlias(from: string, alias: string, salt: bigint, signature: string) {
     const recoveredAddress = await verifySignature(
       SET_ALIAS_TYPES,
       {
         from,
         alias,
-        timestamp,
         salt
       },
       signature
@@ -33,11 +25,6 @@ export default class Aliases extends Agent {
     this.assert(saltAlreadyUsed === false, 'Salt already used');
 
     this.write(`salts:${salt}`, true);
-    this.emit('setAlias', [
-      from,
-      alias,
-      `0x${timestamp.toString(16)}`,
-      `0x${salt.toString(16)}`
-    ]);
+    this.emit('setAlias', [from, alias, `0x${salt.toString(16)}`]);
   }
 }

--- a/src/agents/aliases.ts
+++ b/src/agents/aliases.ts
@@ -24,7 +24,11 @@ export default class Aliases extends Agent {
     const saltAlreadyUsed = await this.has(`salts:${salt}`);
     this.assert(saltAlreadyUsed === false, 'Salt already used');
 
+    const aliasAlreadyExists = await this.has(`aliases:${from}-${alias}`);
+    this.assert(aliasAlreadyExists === false, 'Alias already exists');
+
     this.write(`salts:${salt}`, true);
+    this.write(`aliases:${from}-${alias}`, true);
     this.emit('setAlias', [from, alias, `0x${salt.toString(16)}`]);
   }
 }

--- a/src/agents/aliases.ts
+++ b/src/agents/aliases.ts
@@ -13,8 +13,8 @@ export default class Aliases extends Agent {
   async setAlias(
     from: string,
     alias: string,
-    timestamp: number,
-    salt: string,
+    timestamp: bigint,
+    salt: bigint,
     signature: string
   ) {
     const recoveredAddress = await verifySignature(
@@ -33,6 +33,11 @@ export default class Aliases extends Agent {
     this.assert(saltAlreadyUsed === false, 'Salt already used');
 
     this.write(`salts:${salt}`, true);
-    this.emit('setAlias', [from, alias]);
+    this.emit('setAlias', [
+      from,
+      alias,
+      `0x${timestamp.toString(16)}`,
+      `0x${salt.toString(16)}`
+    ]);
   }
 }

--- a/src/api/config.json
+++ b/src/api/config.json
@@ -4,7 +4,12 @@
     {
       "contract": "aliases",
       "start": 1,
-      "events": []
+      "events": [
+        {
+          "name": "setAlias",
+          "fn": "handleSetAlias"
+        }
+      ]
     }
   ]
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,6 +4,7 @@ import Checkpoint, { LogLevel } from '@snapshot-labs/checkpoint';
 import config from './config.json';
 import { HighlightIndexer } from './indexer';
 import overrides from './overrides.json';
+import { createWriters } from './writers';
 
 const dir = __dirname.endsWith('dist/src/api') ? '../' : '';
 const schemaFile = path.join(__dirname, `${dir}../../src/api/schema.gql`);
@@ -20,7 +21,7 @@ export const checkpoint = new Checkpoint(schema, {
   overridesConfig: overrides
 });
 
-const highlightIndexer = new HighlightIndexer({});
+const highlightIndexer = new HighlightIndexer(createWriters('highlight'));
 checkpoint.addIndexer('highlight', config, highlightIndexer);
 
 async function start() {

--- a/src/api/schema.gql
+++ b/src/api/schema.gql
@@ -2,4 +2,5 @@ type Alias {
   id: String!
   address: String!
   alias: String!
+  created: Int!
 }

--- a/src/api/schema.gql
+++ b/src/api/schema.gql
@@ -1,3 +1,5 @@
-type Aliases {
+type Alias {
   id: String!
+  address: String!
+  alias: String!
 }

--- a/src/api/writers.ts
+++ b/src/api/writers.ts
@@ -3,11 +3,12 @@ import { Alias } from '../../.checkpoint/models';
 
 export function createWriters(indexerName: string) {
   const handleSetAlias: Writer = async ({ payload }) => {
-    const id = `${payload.data[0]}:${payload.data[1]}`;
+    const [from, to, timestamp, salt] = payload.data;
 
-    const alias = new Alias(id, indexerName);
-    alias.address = payload.data[0];
-    alias.alias = payload.data[1];
+    const alias = new Alias(salt, indexerName);
+    alias.address = from;
+    alias.alias = to;
+    alias.created = Number(BigInt(timestamp));
 
     await alias.save();
   };

--- a/src/api/writers.ts
+++ b/src/api/writers.ts
@@ -1,0 +1,16 @@
+import { Writer } from './indexer/types';
+import { Alias } from '../../.checkpoint/models';
+
+export function createWriters(indexerName: string) {
+  const handleSetAlias: Writer = async ({ payload }) => {
+    const id = `${payload.data[0]}:${payload.data[1]}`;
+
+    const alias = new Alias(id, indexerName);
+    alias.address = payload.data[0];
+    alias.alias = payload.data[1];
+
+    await alias.save();
+  };
+
+  return { handleSetAlias };
+}

--- a/src/api/writers.ts
+++ b/src/api/writers.ts
@@ -3,9 +3,9 @@ import { Alias } from '../../.checkpoint/models';
 
 export function createWriters(indexerName: string) {
   const handleSetAlias: Writer = async ({ unit, payload }) => {
-    const [from, to, salt] = payload.data;
+    const [from, to] = payload.data;
 
-    const alias = new Alias(salt, indexerName);
+    const alias = new Alias(`${from}:${to}`, indexerName);
     alias.address = from;
     alias.alias = to;
     alias.created = unit.timestamp;

--- a/src/api/writers.ts
+++ b/src/api/writers.ts
@@ -2,13 +2,13 @@ import { Writer } from './indexer/types';
 import { Alias } from '../../.checkpoint/models';
 
 export function createWriters(indexerName: string) {
-  const handleSetAlias: Writer = async ({ payload }) => {
-    const [from, to, timestamp, salt] = payload.data;
+  const handleSetAlias: Writer = async ({ unit, payload }) => {
+    const [from, to, salt] = payload.data;
 
     const alias = new Alias(salt, indexerName);
     alias.address = from;
     alias.alias = to;
-    alias.created = Number(BigInt(timestamp));
+    alias.created = unit.timestamp;
 
     await alias.save();
   };

--- a/src/highlight/agent.ts
+++ b/src/highlight/agent.ts
@@ -1,5 +1,4 @@
 import { Interface } from '@ethersproject/abi';
-import * as changeCase from 'change-case';
 import Process from './process';
 
 export default class Agent {
@@ -20,7 +19,7 @@ export default class Agent {
   invoke(data: string) {
     const parsed = this.iface.parseTransaction({ data });
 
-    const handlerName = changeCase.snakeCase(parsed.name);
+    const handlerName = parsed.name;
     const parsedArgs = parsed.args.map(arg => {
       if (arg._isBigNumber) {
         return arg.toNumber();

--- a/src/highlight/agent.ts
+++ b/src/highlight/agent.ts
@@ -22,7 +22,7 @@ export default class Agent {
     const handlerName = parsed.name;
     const parsedArgs = parsed.args.map(arg => {
       if (arg._isBigNumber) {
-        return arg.toNumber();
+        return arg.toBigInt();
       }
 
       return arg;

--- a/src/highlight/highlight.ts
+++ b/src/highlight/highlight.ts
@@ -27,19 +27,13 @@ export default class Highlight {
   }
 
   async _postJoint(params: PostJointRequest) {
-    let execution;
     let steps = 0;
 
     const process = new Process({ adapter: this.adapter });
-    try {
-      await this.invoke(process, params.unit.toAddress, params.unit.data);
+    await this.invoke(process, params.unit.toAddress, params.unit.data);
 
-      execution = await process.execute();
-      steps = process.steps;
-    } catch (e) {
-      console.log(e);
-      throw e;
-    }
+    const execution = await process.execute();
+    steps = process.steps;
 
     let id: number = (await this.adapter.get('units:id')) || 0;
 

--- a/test/integration/highlight.test.ts
+++ b/test/integration/highlight.test.ts
@@ -1,112 +1,112 @@
 import { Interface } from '@ethersproject/abi';
-import { expect, it } from 'vitest';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { Wallet } from '@ethersproject/wallet';
+import { describe, expect, it } from 'vitest';
+import { AGENTS_MAP } from '../../src/agents';
+import AliasesAbi from '../../src/agents/abis/aliases.json';
+import { SET_ALIAS_TYPES } from '../../src/agents/aliases';
+import { signMessage } from '../../src/agents/utils/eip712';
 import { MemoryAdapter } from '../../src/highlight/adapter/memory';
-import Agent from '../../src/highlight/agent';
 import Highlight from '../../src/highlight/highlight';
-import Process from '../../src/highlight/process';
 import { PendingUnit } from '../../src/highlight/types';
 
-const PROFILES_ABI = [
-  'function setProfile(string user, string metadataURI)',
-  'function setStatement(string user, string org, string metadataURI)'
-];
-
+const PRIVATE_KEY =
+  '0x6e8d65443b59362a32762cf8409b5ba307f64ee9db4a3d0cff00fbdf49d0d2d6';
 const SENDER_ADDRESS = '0x1111111111111111111111111111111111111111';
-const PROFILES_ADDRESS = '0x0000000000000000000000000000000000000001';
+const ALIASES_ADDRESS = '0x0000000000000000000000000000000000000001';
+const FAKE_SIGNATURE =
+  '0x9a40ce5d706efe66cdc1b9075b866ba25385bf083bbc19b7e1ce315ac2a3957f3a6e075762f6f4723006889ed341ce740e023959f6c600e30586f005f5afa64a1c';
 
-export const AGENTS_MAP = {
-  [PROFILES_ADDRESS]: (process: Process) => {
-    return new Profiles('profiles', process, PROFILES_ABI);
-  }
-};
-
-const profilesInterface = new Interface(PROFILES_ABI);
-
-export default class Profiles extends Agent {
-  async setProfile(user: string, metadataURI: string) {
-    this.emit('set_profile', [user, metadataURI]);
-  }
-
-  async setStatement(user: string, org: string, metadataURI: string) {
-    this.emit('set_statement', [user, org, metadataURI]);
-  }
-}
-
+const provider = new StaticJsonRpcProvider('https://rpc.snapshot.org/11155111');
 const adapter = new MemoryAdapter();
 const highlight = new Highlight({ adapter, agents: AGENTS_MAP });
+const wallet = new Wallet(PRIVATE_KEY, provider);
+const aliasesInterface = new Interface(AliasesAbi);
 
-it('should handle setProfile', async () => {
-  const data = profilesInterface.encodeFunctionData('setProfile', [
-    'sekhmet',
-    'https://example.com/metadata.json'
+async function getUnit(
+  message: {
+    from: string;
+    alias: string;
+    salt: string;
+  },
+  opts: { useFakeSignature?: boolean } = {}
+): Promise<PendingUnit> {
+  const signature = opts.useFakeSignature
+    ? FAKE_SIGNATURE
+    : await signMessage(wallet, SET_ALIAS_TYPES, message);
+
+  const data = aliasesInterface.encodeFunctionData('setAlias', [
+    message.from,
+    message.alias,
+    message.salt,
+    signature
   ]);
 
-  const unit: PendingUnit = {
+  return {
     version: '0x1',
     timestamp: 1744125549,
     senderAddress: SENDER_ADDRESS,
-    toAddress: PROFILES_ADDRESS,
+    toAddress: ALIASES_ADDRESS,
     data
   };
+}
 
-  const res = await highlight.postJoint({
-    unit
+describe('setAlias', () => {
+  it('should emit event', async () => {
+    const message = {
+      from: await wallet.getAddress(),
+      alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+      salt: '0x0'
+    };
+
+    const unit = await getUnit(message);
+    const res = await highlight.postJoint({ unit });
+
+    expect(res).toEqual({
+      joint: {
+        unit: {
+          ...unit,
+          id: 0
+        }
+      },
+      events: [
+        {
+          agent: 'aliases',
+          data: [message.from, message.alias, message.salt],
+          key: 'setAlias'
+        }
+      ],
+      steps: 3,
+      unit_id: 1
+    });
   });
 
-  expect(res).toEqual({
-    joint: {
-      unit: {
-        ...unit,
-        id: 0
-      }
-    },
-    events: [
-      {
-        agent: 'profiles',
-        data: ['sekhmet', 'https://example.com/metadata.json'],
-        key: 'set_profile'
-      }
-    ],
-    steps: 1,
-    unit_id: 1
-  });
-});
+  it('should throw when salt is reused', async () => {
+    const message = {
+      from: await wallet.getAddress(),
+      alias: '0x537f1896541d28F4c70116EEa602b1B34Da95163',
+      salt: '0x0'
+    };
 
-it('should handle setStatement', async () => {
-  const data = profilesInterface.encodeFunctionData('setStatement', [
-    'sekhmet',
-    'snapshot',
-    'https://example.com/metadata.json'
-  ]);
+    const unit = await getUnit(message);
 
-  const unit: PendingUnit = {
-    version: '0x1',
-    timestamp: 1744125549,
-    senderAddress: SENDER_ADDRESS,
-    toAddress: PROFILES_ADDRESS,
-    data
-  };
-
-  const res = await highlight.postJoint({
-    unit
+    await expect(highlight.postJoint({ unit })).rejects.toThrow(
+      'Salt already used'
+    );
   });
 
-  expect(res).toEqual({
-    joint: {
-      unit: {
-        ...unit,
-        id: 1
-      }
-    },
-    events: [
-      {
-        agent: 'profiles',
-        data: ['sekhmet', 'snapshot', 'https://example.com/metadata.json'],
-        key: 'set_statement'
-      }
-    ],
-    steps: 1,
-    unit_id: 2
+  it('should throw when signature is invalid', async () => {
+    const message = {
+      from: await wallet.getAddress(),
+      alias: '0x537f1896541d28F4c70116EEa602b1B34Da95163',
+      salt: '0x1'
+    };
+
+    const unit = await getUnit(message, { useFakeSignature: true });
+
+    await expect(highlight.postJoint({ unit })).rejects.toThrow(
+      'Invalid signature'
+    );
   });
 });
 
@@ -118,13 +118,17 @@ it('should retrieve unit receipt', async () => {
   expect(receipt).toEqual({
     events: [
       {
-        agent: 'profiles',
-        data: ['sekhmet', 'https://example.com/metadata.json'],
-        key: 'set_profile'
+        agent: 'aliases',
+        data: [
+          '0x15Bb65c57Fc440f3aC4FBeEC68137b084416474b',
+          '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+          '0x0'
+        ],
+        key: 'setAlias'
       }
     ],
     unit: {
-      data: '0x719e37ae00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000773656b686d657400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002168747470733a2f2f6578616d706c652e636f6d2f6d657461646174612e6a736f6e00000000000000000000000000000000000000000000000000000000000000',
+      data: '0xb0dd584800000000000000000000000015bb65c57fc440f3ac4fbeec68137b084416474b000000000000000000000000556b14cbda79a36dc33fcd461a04a5bcb5dc2a70000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000041f7379a6ec3a1dd0b99fd3caf0efb7187bb0a53b02951b660bf33ecbf857f73f62bb13ba5e8752cf1b7554d673e3b91e700d4d9637c605066f77eed46dd55698c1c00000000000000000000000000000000000000000000000000000000000000',
       id: 0,
       senderAddress: '0x1111111111111111111111111111111111111111',
       timestamp: 1744125549,
@@ -137,5 +141,5 @@ it('should retrieve unit receipt', async () => {
 it('should retrieve MCI', async () => {
   const mci = await highlight.getMci();
 
-  expect(mci).toEqual(2);
+  expect(mci).toEqual(1);
 });

--- a/test/integration/highlight.test.ts
+++ b/test/integration/highlight.test.ts
@@ -76,7 +76,7 @@ describe('setAlias', () => {
           key: 'setAlias'
         }
       ],
-      steps: 3,
+      steps: 5,
       unit_id: 1
     });
   });
@@ -92,6 +92,20 @@ describe('setAlias', () => {
 
     await expect(highlight.postJoint({ unit })).rejects.toThrow(
       'Salt already used'
+    );
+  });
+
+  it('should throw when alias is reused', async () => {
+    const message = {
+      from: await wallet.getAddress(),
+      alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+      salt: '0x1'
+    };
+
+    const unit = await getUnit(message);
+
+    await expect(highlight.postJoint({ unit })).rejects.toThrow(
+      'Alias already exists'
     );
   });
 

--- a/test/integration/highlight.test.ts
+++ b/test/integration/highlight.test.ts
@@ -23,11 +23,11 @@ export const AGENTS_MAP = {
 const profilesInterface = new Interface(PROFILES_ABI);
 
 export default class Profiles extends Agent {
-  async set_profile(user: string, metadataURI: string) {
+  async setProfile(user: string, metadataURI: string) {
     this.emit('set_profile', [user, metadataURI]);
   }
 
-  async set_statement(user: string, org: string, metadataURI: string) {
+  async setStatement(user: string, org: string, metadataURI: string) {
     this.emit('set_statement', [user, org, metadataURI]);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1642,23 +1642,6 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camel-case@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
-  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
-  dependencies:
-    pascal-case "^3.1.2"
-    tslib "^2.0.3"
-
-capital-case@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
-  integrity sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-    upper-case-first "^2.0.2"
-
 chai@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-5.2.0.tgz#1358ee106763624114addf84ab02697e411c9c05"
@@ -1677,24 +1660,6 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
-
-change-case@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"
-  integrity sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
-  dependencies:
-    camel-case "^4.1.2"
-    capital-case "^1.0.4"
-    constant-case "^3.0.4"
-    dot-case "^3.0.4"
-    header-case "^2.0.4"
-    no-case "^3.0.4"
-    param-case "^3.0.4"
-    pascal-case "^3.1.2"
-    path-case "^3.0.4"
-    sentence-case "^3.0.4"
-    snake-case "^3.0.4"
-    tslib "^2.0.3"
 
 check-error@^2.1.1:
   version "2.1.1"
@@ -1771,15 +1736,6 @@ connection-string@^4.3.5:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/connection-string/-/connection-string-4.4.0.tgz#9849dd252f483dc2cbcb75a25865c6b321fb9e90"
   integrity sha512-D4xsUjSoE8m/B5yMOvCIHY+2ME6FIZhCq0NzBBT57Q8BuL7ArFhBK04osOfReoW4KFr5ztzFwWRdmnv9rCvu2w==
-
-constant-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.4.tgz#3b84a9aeaf4cf31ec45e6bf5de91bdfb0589faf1"
-  integrity sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-    upper-case "^2.0.2"
 
 content-disposition@0.5.4:
   version "0.5.4"
@@ -1956,14 +1912,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-dot-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
-  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
 
 dotenv@^16.0.1:
   version "16.0.1"
@@ -2797,14 +2745,6 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-header-case@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
-  integrity sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==
-  dependencies:
-    capital-case "^1.0.4"
-    tslib "^2.0.3"
-
 help-me@^4.0.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/help-me/-/help-me-4.2.0.tgz#50712bfd799ff1854ae1d312c36eafcea85b0563"
@@ -3238,13 +3178,6 @@ loupe@^3.1.0, loupe@^3.1.3:
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.3.tgz#042a8f7986d77f3d0f98ef7990a2b2fef18b0fd2"
   integrity sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==
 
-lower-case@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
-  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
-  dependencies:
-    tslib "^2.0.3"
-
 magic-string@^0.30.17:
   version "0.30.17"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
@@ -3384,14 +3317,6 @@ negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
-
-no-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
-  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
-  dependencies:
-    lower-case "^2.0.2"
-    tslib "^2.0.3"
 
 node-fetch@^2.6.1:
   version "2.6.9"
@@ -3568,14 +3493,6 @@ pako@^2.0.4:
   resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
   integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
-param-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
-  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
-  dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -3587,22 +3504,6 @@ parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
-
-pascal-case@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
-  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-
-path-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
-  integrity sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==
-  dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -4210,15 +4111,6 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-sentence-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
-  integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-    upper-case-first "^2.0.2"
-
 serve-static@1.15.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
@@ -4337,14 +4229,6 @@ simple-update-notifier@^1.0.7:
   integrity sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==
   dependencies:
     semver "~7.0.0"
-
-snake-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
-  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
-  dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
 
 sonic-boom@^3.0.0, sonic-boom@^3.1.0:
   version "3.6.1"
@@ -4598,7 +4482,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.1, tslib@^2.0.3, tslib@^2.4.0:
+tslib@^2.0.1, tslib@^2.4.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -4712,20 +4596,6 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
-
-upper-case-first@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
-  integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
-  dependencies:
-    tslib "^2.0.3"
-
-upper-case@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.2.tgz#d89810823faab1df1549b7d97a76f8662bae6f7a"
-  integrity sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==
-  dependencies:
-    tslib "^2.0.3"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
## Summary

Depends on: https://github.com/snapshot-labs/highlight/pull/24

This PR adds alias that can be indexed by the API:

1. Salt is tested to make sure it's not validated.
2. Add `timestamp` to setAlias.
3. Remove `camelCase` - as we use ABI to encode data I think it's fair to make sure to match those to avoid confusion.

## Test plan
1. Tests pass.
2. Execute query below.
```bash
curl --request POST \
  --url http://localhost:3000/highlight \
  --header 'content-type: application/json' \
  --data '{
  "method": "hl_postJoint",
  "params": {
    "from": "0x0",
    "to": "0x0000000000000000000000000000000000000001",
    "data": "0xb0dd584800000000000000000000000015bb65c57fc440f3ac4fbeec68137b084416474b000000000000000000000000537f1896541d28f4c70116eea602b1b34da951630000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000411793f726e8f5ebdc4f4aafd009e5873eb1da53b3e06284d33aefc38c98569509603d1dfc557654e0004031bae5d5f5cb646ef58228790bbeff2fce67f747195c1c00000000000000000000000000000000000000000000000000000000000000"
  }
}'
```
3. Go to http://localhost:3000/
4. Execute query
```gql
{
  aliases {
    id
    address
    alias
    created
  }
}
```
5. You see your alias.