### PR TITLE
feat: add chainId and salt to EIP-712 domain

### DIFF
--- a/src/agents/abis/aliases.json
+++ b/src/agents/abis/aliases.json
@@ -1,3 +1,3 @@
 [
-  "function setAlias(address from, address alias, uint256 salt, bytes signature)"
+  "function setAlias(uint chainId, bytes32 salt, address from, address alias, bytes signature)"
 ]

--- a/src/agents/aliases.test.ts
+++ b/src/agents/aliases.test.ts
@@ -7,6 +7,8 @@ import AliasesAbi from './abis/aliases.json';
 import Aliases, { SET_ALIAS_TYPES } from './aliases';
 import { signMessage } from './utils/eip712';
 
+const CHAIN_ID = '11155111';
+
 const provider = new StaticJsonRpcProvider('https://rpc.snapshot.org/11155111');
 const adapter = new MemoryAdapter();
 const wallet = getWallet();
@@ -23,9 +25,7 @@ function getSalt() {
   const buffer = new Uint8Array(32);
   crypto.getRandomValues(buffer);
 
-  return BigInt(
-    `0x${buffer.reduce((acc, val) => acc + val.toString(16).padStart(2, '0'), '')}`
-  );
+  return `0x${buffer.reduce((acc, val) => acc + val.toString(16).padStart(2, '0'), '')}`;
 }
 
 it('should allow alias if signature is valid', async () => {
@@ -34,26 +34,28 @@ it('should allow alias if signature is valid', async () => {
 
   const from = await wallet.getAddress();
 
+  const salt = getSalt();
   const message = {
     from,
-    alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
-    salt: getSalt()
+    alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'
   };
 
-  const signature = await signMessage(wallet, SET_ALIAS_TYPES, message);
+  const signature = await signMessage(
+    wallet,
+    CHAIN_ID,
+    salt,
+    SET_ALIAS_TYPES,
+    message
+  );
 
   await expect(
-    aliases.setAlias(from, message.alias, message.salt, signature)
+    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
   ).resolves.toBeUndefined();
 
   expect(process.events).toEqual([
     {
       agent: 'aliases',
-      data: [
-        from,
-        '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
-        `0x${message.salt.toString(16)}`
-      ],
+      data: [from, '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70', salt],
       key: 'setAlias'
     }
   ]);
@@ -65,17 +67,17 @@ it('should throw if signature is invalid', async () => {
 
   const from = await wallet.getAddress();
 
+  const salt = getSalt();
   const message = {
     from,
-    alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
-    salt: getSalt()
+    alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'
   };
 
   const signature =
     '0x8b44096237326cc5e9c67f6c847a46f8715945d216269d63e6bc09712d91ba7b48e8ceef2d1c62b37debeda708e6bd1f0a5d5822cd88273830599e51d9d8b78c1b';
 
   await expect(
-    aliases.setAlias(from, message.alias, message.salt, signature)
+    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
   ).rejects.toThrow('Invalid signature');
 
   expect(process.events).toHaveLength(0);
@@ -87,23 +89,29 @@ it('should throw if salt is reused', async () => {
 
   const from = await wallet.getAddress();
 
+  const salt = getSalt();
   const message = {
     from,
     alias: '0xEDeF22EA0505C7296D24109bD90001668493777D',
-    timestamp: 1744209444n,
-    salt: getSalt()
+    timestamp: 1744209444n
   };
 
-  const signature = await signMessage(wallet, SET_ALIAS_TYPES, message);
+  const signature = await signMessage(
+    wallet,
+    CHAIN_ID,
+    salt,
+    SET_ALIAS_TYPES,
+    message
+  );
 
   await expect(
-    aliases.setAlias(from, message.alias, message.salt, signature)
+    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
   ).resolves.toBeUndefined();
 
   expect(process.events).toHaveLength(1);
 
   await expect(
-    aliases.setAlias(from, message.alias, message.salt, signature)
+    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
   ).rejects.toThrow('Salt already used');
 
   expect(process.events).toHaveLength(1);
@@ -115,26 +123,37 @@ it('should throw if alias is reused', async () => {
 
   const from = await wallet.getAddress();
 
+  let salt = getSalt();
   const message = {
     from,
-    alias: '0x9905a3A1bAE3b10AD163Bb3735aE87cd70b84eC4',
-    timestamp: 1744209444n,
-    salt: getSalt()
+    alias: '0x9905a3A1bAE3b10AD163Bb3735aE87cd70b84eC4'
   };
 
-  let signature = await signMessage(wallet, SET_ALIAS_TYPES, message);
+  let signature = await signMessage(
+    wallet,
+    CHAIN_ID,
+    salt,
+    SET_ALIAS_TYPES,
+    message
+  );
 
   await expect(
-    aliases.setAlias(from, message.alias, message.salt, signature)
+    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
   ).resolves.toBeUndefined();
 
   expect(process.events).toHaveLength(1);
 
-  message.salt = getSalt();
-  signature = await signMessage(wallet, SET_ALIAS_TYPES, message);
+  salt = getSalt();
+  signature = await signMessage(
+    wallet,
+    CHAIN_ID,
+    salt,
+    SET_ALIAS_TYPES,
+    message
+  );
 
   await expect(
-    aliases.setAlias(from, message.alias, message.salt, signature)
+    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
   ).rejects.toThrow('Alias already exists');
 
   expect(process.events).toHaveLength(1);

--- a/src/agents/aliases.ts
+++ b/src/agents/aliases.ts
@@ -4,18 +4,24 @@ import { verifySignature } from './utils/eip712';
 export const SET_ALIAS_TYPES = {
   Alias: [
     { name: 'from', type: 'address' },
-    { name: 'alias', type: 'address' },
-    { name: 'salt', type: 'uint256' }
+    { name: 'alias', type: 'address' }
   ]
 };
 export default class Aliases extends Agent {
-  async setAlias(from: string, alias: string, salt: bigint, signature: string) {
+  async setAlias(
+    chainId: string,
+    salt: string,
+    from: string,
+    alias: string,
+    signature: string
+  ) {
     const recoveredAddress = await verifySignature(
+      chainId,
+      salt,
       SET_ALIAS_TYPES,
       {
         from,
-        alias,
-        salt
+        alias
       },
       signature
     );
@@ -29,6 +35,6 @@ export default class Aliases extends Agent {
 
     this.write(`salts:${salt}`, true);
     this.write(`aliases:${from}-${alias}`, true);
-    this.emit('setAlias', [from, alias, `0x${salt.toString(16)}`]);
+    this.emit('setAlias', [from, alias, salt]);
   }
 }

--- a/src/agents/utils/eip712.ts
+++ b/src/agents/utils/eip712.ts
@@ -4,23 +4,39 @@ import {
 } from '@ethersproject/abstract-signer';
 import { verifyTypedData, Wallet } from '@ethersproject/wallet';
 
-export const domain: TypedDataDomain = {
+const baseDomain: TypedDataDomain = {
   name: 'highlight',
   version: '0.1.0'
 };
 
 export async function signMessage(
   wallet: Wallet,
+  chainId: Required<TypedDataDomain['chainId']>,
+  salt: string,
   types: Record<string, TypedDataField[]>,
   message: Record<string, any>
 ): Promise<string> {
+  const domain = {
+    ...baseDomain,
+    chainId,
+    salt
+  };
+
   return wallet._signTypedData(domain, types, message);
 }
 
 export async function verifySignature(
+  chainId: Required<TypedDataDomain['chainId']>,
+  salt: string,
   types: Record<string, TypedDataField[]>,
   message: Record<string, any>,
   signature: string
 ) {
+  const domain = {
+    ...baseDomain,
+    chainId,
+    salt
+  };
+
   return verifyTypedData(domain, types, message, signature);
 }


### PR DESCRIPTION
## Summary

This PR adds chainId and salt to EIP-712 domain.
- chainId allows us to verify signature against specific chain.
- salt was already used, but now we use standard salt field in domain.

Because EIP-712's domain's salt is bytes32 it has been updated to match.

## Test plan

- Tests pass.
