### PR TITLE
feat: use new message format

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.8.0",
     "@ethersproject/abstract-signer": "^5.8.0",
+    "@ethersproject/bignumber": "^5.8.0",
     "@ethersproject/contracts": "^5.8.0",
     "@ethersproject/hash": "^5.8.0",
     "@ethersproject/providers": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@ethersproject/wallet": "^5.8.0",
     "@snapshot-labs/checkpoint": "^0.1.0-beta.57",
     "async-lock": "^1.4.0",
+    "change-case": "^4.1.2",
     "connection-string": "^1.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",

--- a/src/agents/abis/aliases.json
+++ b/src/agents/abis/aliases.json
@@ -1,3 +1,0 @@
-[
-  "function setAlias(uint chainId, bytes32 salt, address from, address alias, bytes signature)"
-]

--- a/src/agents/aliases.test.ts
+++ b/src/agents/aliases.test.ts
@@ -45,7 +45,9 @@ it('should create alias', async () => {
     alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'
   };
 
-  await expect(aliases.setAlias(message, { domain })).resolves.toBeUndefined();
+  await expect(
+    aliases.setAlias(message, { domain, signer: from })
+  ).resolves.toBeUndefined();
 
   expect(process.events).toEqual([
     {
@@ -54,6 +56,29 @@ it('should create alias', async () => {
       key: 'setAlias'
     }
   ]);
+});
+
+it('should throw if tries to creates alias for non-signer', async () => {
+  const process = new Process({ adapter });
+  const aliases = new Aliases('aliases', process);
+
+  const from = await wallet.getAddress();
+
+  const domain = {
+    ...BASE_DOMAIN,
+    chainId: CHAIN_ID,
+    verifyingContract: '0x0000000000000000000000000000000000000001',
+    salt: getSalt()
+  };
+
+  const message = {
+    from: '0x9905a3A1bAE3b10AD163Bb3735aE87cd70b84eC4',
+    alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'
+  };
+
+  await expect(
+    aliases.setAlias(message, { domain, signer: from })
+  ).rejects.toThrow('Invalid signer');
 });
 
 it('should throw if alias is reused', async () => {
@@ -74,15 +99,17 @@ it('should throw if alias is reused', async () => {
     alias: '0x9905a3A1bAE3b10AD163Bb3735aE87cd70b84eC4'
   };
 
-  await expect(aliases.setAlias(message, { domain })).resolves.toBeUndefined();
+  await expect(
+    aliases.setAlias(message, { domain, signer: from })
+  ).resolves.toBeUndefined();
 
   expect(process.events).toHaveLength(1);
 
   domain.salt = getSalt();
 
-  await expect(aliases.setAlias(message, { domain })).rejects.toThrow(
-    'Alias already exists'
-  );
+  await expect(
+    aliases.setAlias(message, { domain, signer: from })
+  ).rejects.toThrow('Alias already exists');
 
   expect(process.events).toHaveLength(1);
 });

--- a/src/agents/aliases.test.ts
+++ b/src/agents/aliases.test.ts
@@ -1,11 +1,10 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 import { expect, it } from 'vitest';
+import Aliases from './aliases';
 import { MemoryAdapter } from '../highlight/adapter/memory';
 import Process from '../highlight/process';
-import AliasesAbi from './abis/aliases.json';
-import Aliases, { SET_ALIAS_TYPES } from './aliases';
-import { signMessage } from './utils/signatures';
+import { BASE_DOMAIN } from '../highlight/signatures';
 
 const CHAIN_ID = '11155111';
 
@@ -28,133 +27,62 @@ function getSalt() {
   return `0x${buffer.reduce((acc, val) => acc + val.toString(16).padStart(2, '0'), '')}`;
 }
 
-it('should allow alias if signature is valid', async () => {
+it('should create alias', async () => {
   const process = new Process({ adapter });
-  const aliases = new Aliases('aliases', process, AliasesAbi);
+  const aliases = new Aliases('aliases', process);
 
   const from = await wallet.getAddress();
 
-  const salt = getSalt();
+  const domain = {
+    ...BASE_DOMAIN,
+    chainId: CHAIN_ID,
+    verifyingContract: '0x0000000000000000000000000000000000000001',
+    salt: getSalt()
+  };
+
   const message = {
     from,
     alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'
   };
 
-  const signature = await signMessage(
-    wallet,
-    CHAIN_ID,
-    salt,
-    SET_ALIAS_TYPES,
-    message
-  );
-
-  await expect(
-    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
-  ).resolves.toBeUndefined();
+  await expect(aliases.setAlias(message, { domain })).resolves.toBeUndefined();
 
   expect(process.events).toEqual([
     {
       agent: 'aliases',
-      data: [from, '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70', salt],
+      data: [from, '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70', domain.salt],
       key: 'setAlias'
     }
   ]);
 });
 
-it('should throw if signature is invalid', async () => {
-  const process = new Process({ adapter });
-  const aliases = new Aliases('aliases', process, AliasesAbi);
-
-  const from = await wallet.getAddress();
-
-  const salt = getSalt();
-  const message = {
-    from,
-    alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'
-  };
-
-  const signature =
-    '0x8b44096237326cc5e9c67f6c847a46f8715945d216269d63e6bc09712d91ba7b48e8ceef2d1c62b37debeda708e6bd1f0a5d5822cd88273830599e51d9d8b78c1b';
-
-  await expect(
-    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
-  ).rejects.toThrow('Invalid signature');
-
-  expect(process.events).toHaveLength(0);
-});
-
-it('should throw if salt is reused', async () => {
-  const process = new Process({ adapter });
-  const aliases = new Aliases('aliases', process, AliasesAbi);
-
-  const from = await wallet.getAddress();
-
-  const salt = getSalt();
-  const message = {
-    from,
-    alias: '0xEDeF22EA0505C7296D24109bD90001668493777D',
-    timestamp: 1744209444n
-  };
-
-  const signature = await signMessage(
-    wallet,
-    CHAIN_ID,
-    salt,
-    SET_ALIAS_TYPES,
-    message
-  );
-
-  await expect(
-    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
-  ).resolves.toBeUndefined();
-
-  expect(process.events).toHaveLength(1);
-
-  await expect(
-    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
-  ).rejects.toThrow('Salt already used');
-
-  expect(process.events).toHaveLength(1);
-});
-
 it('should throw if alias is reused', async () => {
   const process = new Process({ adapter });
-  const aliases = new Aliases('aliases', process, AliasesAbi);
+  const aliases = new Aliases('aliases', process);
 
   const from = await wallet.getAddress();
 
-  let salt = getSalt();
+  const domain = {
+    ...BASE_DOMAIN,
+    chainId: CHAIN_ID,
+    verifyingContract: '0x0000000000000000000000000000000000000001',
+    salt: getSalt()
+  };
+
   const message = {
     from,
     alias: '0x9905a3A1bAE3b10AD163Bb3735aE87cd70b84eC4'
   };
 
-  let signature = await signMessage(
-    wallet,
-    CHAIN_ID,
-    salt,
-    SET_ALIAS_TYPES,
-    message
-  );
-
-  await expect(
-    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
-  ).resolves.toBeUndefined();
+  await expect(aliases.setAlias(message, { domain })).resolves.toBeUndefined();
 
   expect(process.events).toHaveLength(1);
 
-  salt = getSalt();
-  signature = await signMessage(
-    wallet,
-    CHAIN_ID,
-    salt,
-    SET_ALIAS_TYPES,
-    message
-  );
+  domain.salt = getSalt();
 
-  await expect(
-    aliases.setAlias(CHAIN_ID, salt, from, message.alias, signature)
-  ).rejects.toThrow('Alias already exists');
+  await expect(aliases.setAlias(message, { domain })).rejects.toThrow(
+    'Alias already exists'
+  );
 
   expect(process.events).toHaveLength(1);
 });

--- a/src/agents/aliases.ts
+++ b/src/agents/aliases.ts
@@ -18,10 +18,12 @@ export default class Aliases extends Agent {
 
   async setAlias(
     message: { from: string; alias: string },
-    meta: { domain: Domain }
+    meta: { domain: Domain; signer: string }
   ) {
     const { salt } = meta.domain;
     const { from, alias } = message;
+
+    this.assert(from === meta.signer, 'Invalid signer');
 
     const aliasAlreadyExists = await this.has(`aliases:${from}-${alias}`);
     this.assert(aliasAlreadyExists === false, 'Alias already exists');

--- a/src/agents/aliases.ts
+++ b/src/agents/aliases.ts
@@ -26,7 +26,6 @@ export default class Aliases extends Agent {
     const aliasAlreadyExists = await this.has(`aliases:${from}-${alias}`);
     this.assert(aliasAlreadyExists === false, 'Alias already exists');
 
-    this.write(`salts:${salt}`, true);
     this.write(`aliases:${from}-${alias}`, true);
     this.emit('setAlias', [from, alias, salt]);
   }

--- a/src/agents/aliases.ts
+++ b/src/agents/aliases.ts
@@ -3,7 +3,7 @@ import Process from '../highlight/process';
 import { Domain } from '../highlight/types';
 
 export const SET_ALIAS_TYPES = {
-  Alias: [
+  SetAlias: [
     { name: 'from', type: 'address' },
     { name: 'alias', type: 'address' }
   ]
@@ -13,7 +13,12 @@ export default class Aliases extends Agent {
   constructor(id: string, process: Process) {
     super(id, process);
 
-    this.addEntrypoint('setAlias', SET_ALIAS_TYPES);
+    this.addEntrypoint({
+      SetAlias: [
+        { name: 'from', type: 'address' },
+        { name: 'alias', type: 'address' }
+      ]
+    });
   }
 
   async setAlias(

--- a/src/agents/aliases.ts
+++ b/src/agents/aliases.ts
@@ -1,5 +1,6 @@
 import Agent from '../highlight/agent';
-import { verifySignature } from './utils/signatures';
+import Process from '../highlight/process';
+import { Domain } from '../highlight/types';
 
 export const SET_ALIAS_TYPES = {
   Alias: [
@@ -7,30 +8,20 @@ export const SET_ALIAS_TYPES = {
     { name: 'alias', type: 'address' }
   ]
 };
-export default class Aliases extends Agent {
-  async setAlias(
-    chainId: string,
-    salt: string,
-    from: string,
-    alias: string,
-    signature: string
-  ) {
-    const isSignatureValid = await verifySignature(
-      chainId,
-      salt,
-      from,
-      SET_ALIAS_TYPES,
-      {
-        from,
-        alias
-      },
-      signature,
-      { ecdsa: true, eip1271: true }
-    );
-    this.assert(isSignatureValid, 'Invalid signature');
 
-    const saltAlreadyUsed = await this.has(`salts:${salt}`);
-    this.assert(saltAlreadyUsed === false, 'Salt already used');
+export default class Aliases extends Agent {
+  constructor(id: string, process: Process) {
+    super(id, process);
+
+    this.addEntrypoint('setAlias', SET_ALIAS_TYPES);
+  }
+
+  async setAlias(
+    message: { from: string; alias: string },
+    meta: { domain: Domain }
+  ) {
+    const { salt } = meta.domain;
+    const { from, alias } = message;
 
     const aliasAlreadyExists = await this.has(`aliases:${from}-${alias}`);
     this.assert(aliasAlreadyExists === false, 'Alias already exists');

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,9 +1,8 @@
-import AliasesAbi from './abis/aliases.json';
 import Aliases from './aliases';
 import Process from '../highlight/process';
 
 export const AGENTS_MAP = {
   '0x0000000000000000000000000000000000000001': (process: Process) => {
-    return new Aliases('aliases', process, AliasesAbi);
+    return new Aliases('aliases', process);
   }
 };

--- a/src/highlight/agent.ts
+++ b/src/highlight/agent.ts
@@ -5,7 +5,10 @@ import { PostMessageRequest } from './types';
 export default class Agent {
   public id: string;
   public process: Process;
-  public entrypoints: Record<string, Record<string, TypedDataField[]>> = {};
+  public entrypoints: Record<
+    string,
+    Record<string, TypedDataField[]> | undefined
+  > = {};
 
   constructor(id: string, process: Process) {
     this.id = id;

--- a/src/highlight/agent.ts
+++ b/src/highlight/agent.ts
@@ -17,7 +17,7 @@ export default class Agent {
   }
 
   async invoke(request: PostMessageRequest) {
-    const { entrypoint, domain, message } = request;
+    const { entrypoint, domain, message, signer } = request;
 
     const entrypointTypes = this.entrypoints[entrypoint];
     if (!entrypointTypes) {
@@ -26,7 +26,7 @@ export default class Agent {
 
     const handler = (this as Record<string, any>)[entrypoint];
     if (typeof handler === 'function') {
-      return handler.bind(this)(message, { domain });
+      return handler.bind(this)(message, { domain, signer });
     }
 
     throw new Error(`Handler not found: ${entrypoint}`);

--- a/src/highlight/agent.ts
+++ b/src/highlight/agent.ts
@@ -1,6 +1,5 @@
 import { TypedDataField } from '@ethersproject/abstract-signer';
 import Process from './process';
-import { BASE_DOMAIN, verifySignature } from './signatures';
 import { PostMessageRequest } from './types';
 
 export default class Agent {
@@ -18,34 +17,11 @@ export default class Agent {
   }
 
   async invoke(request: PostMessageRequest) {
-    const { entrypoint, domain, signer, signature, message } = request;
+    const { entrypoint, domain, message } = request;
 
     const entrypointTypes = this.entrypoints[entrypoint];
     if (!entrypointTypes) {
       throw new Error(`Entrypoint not found: ${entrypoint}`);
-    }
-
-    const verifyingDomain = {
-      ...BASE_DOMAIN,
-      chainId: domain.chainId,
-      salt: domain.salt.toString(),
-      verifyingContract: domain.verifyingContract
-    };
-
-    const isSignatureValid = await verifySignature(
-      verifyingDomain,
-      signer,
-      entrypointTypes,
-      message,
-      signature,
-      {
-        ecdsa: true,
-        eip1271: true
-      }
-    );
-
-    if (!isSignatureValid) {
-      throw new Error('Invalid signature');
     }
 
     const handler = (this as Record<string, any>)[entrypoint];

--- a/src/highlight/highlight.ts
+++ b/src/highlight/highlight.ts
@@ -84,6 +84,9 @@ export default class Highlight {
     const agent = getAgent(process);
 
     const entrypointTypes = agent.entrypoints[request.entrypoint];
+    if (!entrypointTypes) {
+      throw new Error(`Entrypoint not found: ${request.entrypoint}`);
+    }
 
     const verifyingDomain = {
       ...BASE_DOMAIN,

--- a/src/highlight/highlight.ts
+++ b/src/highlight/highlight.ts
@@ -83,9 +83,9 @@ export default class Highlight {
     const getAgent = this.agents[domain.verifyingContract.toLowerCase()];
     const agent = getAgent(process);
 
-    const entrypointTypes = agent.entrypoints[request.entrypoint];
+    const entrypointTypes = agent.entrypoints[request.primaryType];
     if (!entrypointTypes) {
-      throw new Error(`Entrypoint not found: ${request.entrypoint}`);
+      throw new Error(`Entrypoint not found: ${request.primaryType}`);
     }
 
     const verifyingDomain = {

--- a/src/highlight/signatures.test.ts
+++ b/src/highlight/signatures.test.ts
@@ -22,7 +22,7 @@ describe('ECDSA', () => {
     };
 
     const signature =
-      '0xf6497f04d464f72e7e628019a60b73b333408f4661cc66c8e476eb4a9210dc966f38c8d20fea33574c8270b26254dceea9379b75f0dbd577efe6429b65278ac61c';
+      '0xb97e0ce664cf74cf1500992eb510a3541d772be062bbb2149e16e440e39cad6863682cda5742085b70b590b71f4f0574315ec850885f55a6a7d65e9d821161ad1c';
 
     const result = await verifyEcdsaSignature(
       createDomain(11155111, salt),
@@ -68,7 +68,7 @@ describe('eip1271', () => {
     };
 
     const signature =
-      '0x275fc929b1ccbc58fabdb159cc0fc85dca668fe0de82e91b91bbd2cd5f49324802d30cb4db5b90c07f3e57781d90947e0c8c500ee7f17674b1d4e0e7593ebf5c1b';
+      '0xb7f4220ee17579e1e11f81c88c9db1f0170fbb1fffec85146e3f9bc619a4524e7a540f7686965c844c9d5d7c809824b208a2e8ac36f6ff8c54a3f8426cdc98be1b';
 
     const result = await verifyEip1271Signature(
       createDomain(11155111, salt),

--- a/src/highlight/signatures.test.ts
+++ b/src/highlight/signatures.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { verifyEcdsaSignature, verifyEip1271Signature } from './signatures';
-import { SET_ALIAS_TYPES } from '../aliases';
+import { SET_ALIAS_TYPES } from '../agents/aliases';
+
+function createDomain(chainId: number, salt: string) {
+  return {
+    name: 'highlight',
+    version: '0.1.0',
+    chainId,
+    salt,
+    verifyingContract: '0x0000000000000000000000000000000000000001'
+  };
+}
 
 describe('ECDSA', () => {
   it('should return true for valid signature', async () => {
@@ -12,11 +22,10 @@ describe('ECDSA', () => {
     };
 
     const signature =
-      '0xf577a9220b23957e94aa0fdc9a2707522ec881fee5484c2142b744d8a8141887056dd9ff79ea740c9353f8f03f0c5a1cf9ad5a41f70c9d3659cb2f5f9724bc3b1c';
+      '0xf6497f04d464f72e7e628019a60b73b333408f4661cc66c8e476eb4a9210dc966f38c8d20fea33574c8270b26254dceea9379b75f0dbd577efe6429b65278ac61c';
 
     const result = await verifyEcdsaSignature(
-      11155111,
-      salt,
+      createDomain(11155111, salt),
       message.from,
       SET_ALIAS_TYPES,
       message,
@@ -38,8 +47,7 @@ describe('ECDSA', () => {
       '0xee4eca1bbcc10a15f862637a9db6987049be7312b13c55bc6e5b1edc7f567f7062fde75eecfbc1abcd0c2807806b5548008bf8b681bea4f8af4da39c1da1b3471c';
 
     const result = await verifyEcdsaSignature(
-      11155111,
-      salt,
+      createDomain(11155111, salt),
       message.from,
       SET_ALIAS_TYPES,
       message,
@@ -60,11 +68,10 @@ describe('eip1271', () => {
     };
 
     const signature =
-      '0x6b5c3987af94800a607cded216769d78b88ddbead9161aa9288c4e7045b912bd0c486b58c5842710396a1941fcee2fbf4fa6bcc345ca51758a62c88e413031991b';
+      '0x275fc929b1ccbc58fabdb159cc0fc85dca668fe0de82e91b91bbd2cd5f49324802d30cb4db5b90c07f3e57781d90947e0c8c500ee7f17674b1d4e0e7593ebf5c1b';
 
     const result = await verifyEip1271Signature(
-      11155111,
-      salt,
+      createDomain(11155111, salt),
       message.from,
       SET_ALIAS_TYPES,
       message,
@@ -86,8 +93,7 @@ describe('eip1271', () => {
       '0xee4eca1bbcc10a15f862637a9db6987049be7312b13c55bc6e5b1edc7f567f7062fde75eecfbc1abcd0c2807806b5548008bf8b681bea4f8af4da39c1da1b3471c';
 
     const result = await verifyEip1271Signature(
-      11155111,
-      salt,
+      createDomain(11155111, salt),
       message.from,
       SET_ALIAS_TYPES,
       message,

--- a/src/highlight/types.ts
+++ b/src/highlight/types.ts
@@ -1,17 +1,23 @@
-export interface PostJointRequest {
-  unit: PendingUnit;
-}
+import { TypedDataDomain } from '@ethersproject/abstract-signer';
+
+export type PostMessageRequest = Message;
+
+export type Domain = Required<TypedDataDomain>;
+
+export type Message = {
+  domain: Domain;
+  message: Record<string, unknown>;
+  entrypoint: string;
+  signer: string;
+  signature: string;
+};
 
 export type Unit = {
   id: number;
   version: string;
   timestamp: number;
-  senderAddress: string;
-  toAddress: string;
-  data: string;
+  message: Message;
 };
-
-export type PendingUnit = Omit<Unit, 'id'>;
 
 export interface GetUnitReceiptRequest {
   id: number;

--- a/src/highlight/types.ts
+++ b/src/highlight/types.ts
@@ -7,7 +7,7 @@ export type Domain = Required<TypedDataDomain>;
 export type Message = {
   domain: Domain;
   message: Record<string, unknown>;
-  entrypoint: string;
+  primaryType: string;
   signer: string;
   signature: string;
 };

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -3,7 +3,6 @@ import { AGENTS_MAP } from './agents';
 import { lastIndexedMci } from './api/indexer/provider';
 import { RedisAdapter } from './highlight/adapter/redis';
 import Highlight from './highlight/highlight';
-import { PendingUnit } from './highlight/types';
 import { rpcError, rpcSuccess, sleep } from './utils';
 
 const DATABASE_URL = process.env.DATABASE_URL || '';
@@ -39,19 +38,9 @@ router.post('/', async (req, res) => {
       }
     }
 
-    case 'hl_postJoint': {
-      const { from, to, data } = params;
-
+    case 'hl_postMessage': {
       try {
-        const unit: PendingUnit = {
-          version: '0x1',
-          timestamp: ~~(Date.now() / 1e3),
-          senderAddress: from,
-          toAddress: to,
-          data
-        };
-
-        const result = await highlight.postJoint({ unit });
+        const result = await highlight.postMessage(params);
 
         while (result.unit_id > lastIndexedMci) {
           await sleep(1e2);

--- a/test/integration/highlight.test.ts
+++ b/test/integration/highlight.test.ts
@@ -49,7 +49,7 @@ async function createRequest(
   return {
     domain,
     message,
-    entrypoint: 'setAlias',
+    primaryType: 'SetAlias',
     signer,
     signature
   };
@@ -174,9 +174,9 @@ it('should retrieve unit receipt', async () => {
           alias: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
           from: '0x15Bb65c57Fc440f3aC4FBeEC68137b084416474b'
         },
-        entrypoint: 'setAlias',
+        primaryType: 'SetAlias',
         signature:
-          '0x38487b45060523bf4d386faea6846071906ea300d30380a95c7bcfe4262c589212cc28dc6ee4d7ac20e6a96ae0e12abe518e55b0e17c588d83997d9764f4a19e1c',
+          '0xd4f5345c22473b6f0040145d0ceb311ce4bc107872160b6d7287ccebcda4005d0e5186d2557ba698da5518ddc66d4ff89e202498b6e75300fd2cfdc3064373241b',
         signer: '0x15Bb65c57Fc440f3aC4FBeEC68137b084416474b'
       },
       timestamp: 1735689600,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,6 +1658,23 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camel-case@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
+  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
+  dependencies:
+    pascal-case "^3.1.2"
+    tslib "^2.0.3"
+
+capital-case@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
+  integrity sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
+
 chai@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-5.2.0.tgz#1358ee106763624114addf84ab02697e411c9c05"
@@ -1676,6 +1693,24 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+change-case@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"
+  integrity sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
+  dependencies:
+    camel-case "^4.1.2"
+    capital-case "^1.0.4"
+    constant-case "^3.0.4"
+    dot-case "^3.0.4"
+    header-case "^2.0.4"
+    no-case "^3.0.4"
+    param-case "^3.0.4"
+    pascal-case "^3.1.2"
+    path-case "^3.0.4"
+    sentence-case "^3.0.4"
+    snake-case "^3.0.4"
+    tslib "^2.0.3"
 
 check-error@^2.1.1:
   version "2.1.1"
@@ -1752,6 +1787,15 @@ connection-string@^4.3.5:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/connection-string/-/connection-string-4.4.0.tgz#9849dd252f483dc2cbcb75a25865c6b321fb9e90"
   integrity sha512-D4xsUjSoE8m/B5yMOvCIHY+2ME6FIZhCq0NzBBT57Q8BuL7ArFhBK04osOfReoW4KFr5ztzFwWRdmnv9rCvu2w==
+
+constant-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.4.tgz#3b84a9aeaf4cf31ec45e6bf5de91bdfb0589faf1"
+  integrity sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case "^2.0.2"
 
 content-disposition@0.5.4:
   version "0.5.4"
@@ -1928,6 +1972,14 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dot-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
+  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 dotenv@^16.0.1:
   version "16.0.1"
@@ -2761,6 +2813,14 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+header-case@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
+  integrity sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==
+  dependencies:
+    capital-case "^1.0.4"
+    tslib "^2.0.3"
+
 help-me@^4.0.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/help-me/-/help-me-4.2.0.tgz#50712bfd799ff1854ae1d312c36eafcea85b0563"
@@ -3194,6 +3254,13 @@ loupe@^3.1.0, loupe@^3.1.3:
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.3.tgz#042a8f7986d77f3d0f98ef7990a2b2fef18b0fd2"
   integrity sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==
 
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  dependencies:
+    tslib "^2.0.3"
+
 magic-string@^0.30.17:
   version "0.30.17"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
@@ -3333,6 +3400,14 @@ negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+  dependencies:
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
 
 node-fetch@^2.6.1:
   version "2.6.9"
@@ -3509,6 +3584,14 @@ pako@^2.0.4:
   resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
   integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
+param-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
+  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -3520,6 +3603,22 @@ parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+pascal-case@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
+  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+
+path-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
+  integrity sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -4127,6 +4226,15 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
+sentence-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
+  integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
+
 serve-static@1.15.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
@@ -4245,6 +4353,14 @@ simple-update-notifier@^1.0.7:
   integrity sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==
   dependencies:
     semver "~7.0.0"
+
+snake-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
+  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 sonic-boom@^3.0.0, sonic-boom@^3.1.0:
   version "3.6.1"
@@ -4503,7 +4619,7 @@ tslib@^2.0.1, tslib@^2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-tslib@^2.8.1:
+tslib@^2.0.3, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -4612,6 +4728,20 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
+upper-case-first@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
+  integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
+  dependencies:
+    tslib "^2.0.3"
+
+upper-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.2.tgz#d89810823faab1df1549b7d97a76f8662bae6f7a"
+  integrity sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==
+  dependencies:
+    tslib "^2.0.3"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Now new message format is introduced.
Entire data is encapsulated in EIP-712 message.
1. Domain contains chainId, verifyingContract (agent address) and salt.
2. Salt and signatures are verified on Highlight level.

## Test plan

1. Run Highlight.
2. Make following request.
```bash
curl --request POST \
  --url http://localhost:3000/highlight \
  --header 'content-type: application/json' \
  --data '{
  "method": "hl_postMessage",
  "params": {
    "domain": {
      "name": "highlight",
      "version": "0.1.0",
      "chainId": 11155111,
      "salt": "0x2f7825c4048760606cca7ddf1f57efbce3fdc2c8443a2e2aa8595992ab4a1494",
      "verifyingContract": "0x0000000000000000000000000000000000000001"
    },
    "message": {
      "from": "0x8eDFcC5f141Ffc2B6892530d1fb21bbCdc74B455",
      "alias": "0xCbe6064F307251a62E457F298C18107C905e2573"
    },
    "primaryType": "SetAlias",
    "signer": "0x8eDFcC5f141Ffc2B6892530d1fb21bbCdc74B455",
    "signature": "0xb7f4220ee17579e1e11f81c88c9db1f0170fbb1fffec85146e3f9bc619a4524e7a540f7686965c844c9d5d7c809824b208a2e8ac36f6ff8c54a3f8426cdc98be1b"
  }
}'
```
3. Make following query on API:
```gql
{
  aliases {
    id
    address
    alias
    created
  }
}
```
4. Your alias is visible.